### PR TITLE
fix: incorrect links

### DIFF
--- a/.changeset/hot-dryers-sleep.md
+++ b/.changeset/hot-dryers-sleep.md
@@ -1,0 +1,5 @@
+---
+'@asgardeo/passport-asgardeo': patch
+---
+
+Fix incorrect URLs for npm

--- a/lib/package.json
+++ b/lib/package.json
@@ -4,13 +4,13 @@
   "description": "Asgardeo Strategy for Passport.js",
   "author": "WSO2",
   "license": "Apache-2.0",
-  "homepage": "https://github.com/asgardeo/asgardeo-passport#readme",
+  "homepage": "https://github.com/asgardeo/passport-asgardeo#readme",
   "bugs": {
-    "url": "https://github.com/asgardeo/asgardeo-passport/issues"
+    "url": "https://github.com/asgardeo/passport-asgardeo/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/asgardeo/asgardeo-passport",
+    "url": "https://github.com/asgardeo/passport-asgardeo",
     "directory": "lib"
   },
   "keywords": [


### PR DESCRIPTION
### Purpose
This fix corrects the URL displayed in the Passport Asgardeo NPM package. 

## Related Issues
- https://github.com/asgardeo/passport-asgardeo/issues/4

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran ESLint & Prettier plugins and verified?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
